### PR TITLE
Export methods to retrieve errors on failed executions

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,46 +1,55 @@
 name: golangci-lint
 on:
   push:
-    tags:
-      - v*
     branches:
       - master
       - main
   pull_request:
+
 permissions:
   contents: read
   # Optional: allow read access to pull request. Use with `only-new-issues` option.
   # pull-requests: read
+
 jobs:
-  lint:
+  golangci:
+    name: lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
           go-version: '1.21'
           cache: false
-      - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.29
+          # Require: The version of golangci-lint to use.
+          # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.
+          # When `install-mode` is `goinstall` the value can be v1.2.3, `latest`, or the hash of a commit.
+          version: v1.54
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir
 
           # Optional: golangci-lint command line arguments.
-          # args: --issues-exit-code=0
+          #
+          # Note: By default, the `.golangci.yml` file should be at the root of the repository.
+          # The location of the configuration file can be changed by using `--config=`
+          # args: --timeout=30m --config=/my/path/.golangci.yml --issues-exit-code=0
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true
 
-          # Optional: if set to true then the all caching functionality will be complete disabled,
+          # Optional: if set to true, then all caching functionality will be completely disabled,
           #           takes precedence over all other caching options.
           # skip-cache: true
 
-          # Optional: if set to true then the action don't cache or restore ~/go/pkg.
+          # Optional: if set to true, then the action won't cache or restore ~/go/pkg.
           # skip-pkg-cache: true
 
-          # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
+          # Optional: if set to true, then the action won't cache or restore ~/.cache/go-build.
           # skip-build-cache: true
+
+          # Optional: The mode to install golangci-lint. It can be 'binary' or 'goinstall'.
+          # install-mode: "goinstall"

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ func main() {
 	result := p.Process(inputSet)
 	resultBytes, _ := json.Marshal(result)
 	fmt.Println(string(resultBytes))
+	// Error Handling:
+	fmt.Println(result.GetErrors()) 
+	
 }
 ```
 

--- a/async/processor.go
+++ b/async/processor.go
@@ -18,3 +18,23 @@ type ProcessResult struct {
 	Results  []JobResult
 	HasError bool
 }
+
+// GetError return bool when job has failed and the error
+func (j *JobResult) GetError() (bool, error) {
+	if j.Err != nil {
+		return true, j.Err
+	}
+	return false, nil
+}
+
+// GetErrors return all errors from failed jobs, it uses HasError flag to minimize allocations on getting errors
+func (p *ProcessResult) GetErrors() (errs []error) {
+	if p.HasError {
+		for _, r := range p.Results {
+			if r.Err != nil {
+				errs = append(errs, r.Err)
+			}
+		}
+	}
+	return errs
+}

--- a/async/processor_test.go
+++ b/async/processor_test.go
@@ -2,9 +2,10 @@ package async_test
 
 import (
 	"errors"
+	"testing"
+
 	"github.com/f-amaral/go-async/async"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestJobResult_GetError_WhenError(t *testing.T) {
@@ -27,7 +28,6 @@ func TestJobResult_GetError_WhenNoError(t *testing.T) {
 	ok, err := jobResult.GetError()
 	assert.False(t, ok)
 	assert.Nil(t, err)
-
 }
 
 func TestProcessResult_GetErrors_WhenJobsHaveErrors(t *testing.T) {
@@ -51,8 +51,10 @@ func TestProcessResult_GetErrors_WhenJobsDontHaveErrors(t *testing.T) {
 }
 
 // region Benchmarks
-var errs []error
-var err error
+var (
+	errs []error
+	err  error
+)
 
 func BenchmarkJobResult_GetError_WhenError(b *testing.B) {
 	var jobResult async.JobResult

--- a/async/processor_test.go
+++ b/async/processor_test.go
@@ -52,6 +52,27 @@ func TestProcessResult_GetErrors_WhenJobsDontHaveErrors(t *testing.T) {
 
 // region Benchmarks
 var errs []error
+var err error
+
+func BenchmarkJobResult_GetError_WhenError(b *testing.B) {
+	var jobResult async.JobResult
+	jobResult = buildJobResultWithErr()
+	var result error
+	for i := 0; i < b.N; i++ {
+		_, result = jobResult.GetError()
+	}
+	err = result
+}
+
+func BenchmarkJobResult_GetError_WhenNoError(b *testing.B) {
+	var jobResult async.JobResult
+	jobResult = buildJobResultWithoutErr()
+	var result error
+	for i := 0; i < b.N; i++ {
+		_, result = jobResult.GetError()
+	}
+	err = result
+}
 
 func BenchmarkProcessResult_GetErrors(b *testing.B) {
 	var processResult async.ProcessResult
@@ -99,6 +120,22 @@ func buildJobResultsWithoutErrs() []async.JobResult {
 		})
 	}
 	return jobResults
+}
+
+func buildJobResultWithoutErr() async.JobResult {
+	return async.JobResult{
+		Input:  1,
+		Output: 2,
+		Err:    nil,
+	}
+}
+
+func buildJobResultWithErr() async.JobResult {
+	return async.JobResult{
+		Input:  1,
+		Output: 2,
+		Err:    assert.AnError,
+	}
 }
 
 // endregion

--- a/async/processor_test.go
+++ b/async/processor_test.go
@@ -1,0 +1,104 @@
+package async_test
+
+import (
+	"errors"
+	"github.com/f-amaral/go-async/async"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestJobResult_GetError_WhenError(t *testing.T) {
+	jobResult := async.JobResult{
+		Input:  1,
+		Output: 2,
+		Err:    assert.AnError,
+	}
+	ok, err := jobResult.GetError()
+	assert.True(t, ok)
+	assert.Equal(t, assert.AnError, err)
+}
+
+func TestJobResult_GetError_WhenNoError(t *testing.T) {
+	jobResult := async.JobResult{
+		Input:  1,
+		Output: 2,
+		Err:    nil,
+	}
+	ok, err := jobResult.GetError()
+	assert.False(t, ok)
+	assert.Nil(t, err)
+
+}
+
+func TestProcessResult_GetErrors_WhenJobsHaveErrors(t *testing.T) {
+	jobResults := buildJobResultsWithErrs()
+	processResult := async.ProcessResult{
+		Results:  jobResults,
+		HasError: true,
+	}
+	errs := processResult.GetErrors()
+	assert.Equal(t, len(jobResults), len(errs))
+}
+
+func TestProcessResult_GetErrors_WhenJobsDontHaveErrors(t *testing.T) {
+	jobResults := buildJobResultsWithoutErrs()
+	processResult := async.ProcessResult{
+		Results:  jobResults,
+		HasError: false,
+	}
+	errs := processResult.GetErrors()
+	assert.Equal(t, 0, len(errs))
+}
+
+// region Benchmarks
+var errs []error
+
+func BenchmarkProcessResult_GetErrors(b *testing.B) {
+	var processResult async.ProcessResult
+	var results []error
+	processResult.Results = buildJobResultsWithErrs()
+	for i := 0; i < b.N; i++ {
+		results = processResult.GetErrors()
+	}
+	errs = results
+}
+
+func BenchmarkProcessResult_GetErrors_WhenNoErrors(b *testing.B) {
+	var processResult async.ProcessResult
+	var results []error
+	processResult.Results = buildJobResultsWithoutErrs()
+	for i := 0; i < b.N; i++ {
+		results = processResult.GetErrors()
+	}
+	errs = results
+}
+
+// endregion
+
+// region Test Support
+
+func buildJobResultsWithErrs() []async.JobResult {
+	var jobResults []async.JobResult
+	for i := 0; i < 100; i++ {
+		jobResults = append(jobResults, async.JobResult{
+			Input:  i,
+			Output: i * 2,
+			Err:    errors.New("error"),
+		})
+	}
+	return jobResults
+}
+
+func buildJobResultsWithoutErrs() []async.JobResult {
+	var jobResults []async.JobResult
+	for i := 0; i < 100; i++ {
+		jobResults = append(jobResults, async.JobResult{
+			Input:  i,
+			Output: i * 2,
+			Err:    nil,
+		})
+	}
+	return jobResults
+}
+
+// endregion

--- a/async/processor_test.go
+++ b/async/processor_test.go
@@ -57,8 +57,7 @@ var (
 )
 
 func BenchmarkJobResult_GetError_WhenError(b *testing.B) {
-	var jobResult async.JobResult
-	jobResult = buildJobResultWithErr()
+	jobResult := buildJobResultWithErr()
 	var result error
 	for i := 0; i < b.N; i++ {
 		_, result = jobResult.GetError()
@@ -67,8 +66,7 @@ func BenchmarkJobResult_GetError_WhenError(b *testing.B) {
 }
 
 func BenchmarkJobResult_GetError_WhenNoError(b *testing.B) {
-	var jobResult async.JobResult
-	jobResult = buildJobResultWithoutErr()
+	jobResult := buildJobResultWithoutErr()
 	var result error
 	for i := 0; i < b.N; i++ {
 		_, result = jobResult.GetError()

--- a/pool/example_test.go
+++ b/pool/example_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 // ExampleJobPool_ProcessOneDataSet demonstrates how to use the JobPool to process one dataset.
+//
+//nolint:all
 func ExampleJobPool_Process_OneDataSet() {
 	numbers := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 
@@ -25,6 +27,8 @@ func ExampleJobPool_Process_OneDataSet() {
 }
 
 // ExampleJobPool_Process demonstrates how to use the JobPool to more than one dataset with the same shared workers.
+//
+//nolint:all
 func ExampleJobPool_Process_MultipleInputsInSameWorkerPool() {
 	odds := []int{1, 3, 5, 7, 9}
 	evens := []int{2, 4, 6, 8, 10}

--- a/pool/jobpool_test.go
+++ b/pool/jobpool_test.go
@@ -1,6 +1,7 @@
 package pool_test
 
 import (
+	"github.com/f-amaral/go-async/async"
 	"testing"
 
 	"github.com/f-amaral/go-async/pool"
@@ -62,3 +63,43 @@ func TestJobPool_Close(t *testing.T) {
 		})
 	})
 }
+
+// region Benchmarks
+var result async.ProcessResult
+
+func buildData() []int {
+	return []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+}
+
+func processWithoutErr(i int) (int, error) {
+	return i * 2, nil
+}
+
+func processWithErr(i int) (int, error) {
+	return i, assert.AnError
+}
+
+func BenchmarkJobPool_Process_WithoutErr(b *testing.B) {
+	var processResult async.ProcessResult
+	p := pool.NewPool(10, processWithoutErr)
+	data := buildData()
+	defer p.Close()
+	for i := 0; i < b.N; i++ {
+		processResult = p.Process(data)
+
+	}
+	result = processResult
+}
+
+func BenchmarkJobPool_Process_WithErr(b *testing.B) {
+	var processResult async.ProcessResult
+	p := pool.NewPool(10, processWithErr)
+	data := buildData()
+	defer p.Close()
+	for i := 0; i < b.N; i++ {
+		processResult = p.Process(data)
+	}
+	result = processResult
+}
+
+// endregion

--- a/pool/jobpool_test.go
+++ b/pool/jobpool_test.go
@@ -1,8 +1,9 @@
 package pool_test
 
 import (
-	"github.com/f-amaral/go-async/async"
 	"testing"
+
+	"github.com/f-amaral/go-async/async"
 
 	"github.com/f-amaral/go-async/pool"
 	"github.com/stretchr/testify/assert"
@@ -86,7 +87,6 @@ func BenchmarkJobPool_Process_WithoutErr(b *testing.B) {
 	defer p.Close()
 	for i := 0; i < b.N; i++ {
 		processResult = p.Process(data)
-
 	}
 	result = processResult
 }


### PR DESCRIPTION
This PR adds functionality to better retrieve errors that occurred during async execution. 

This methods focus on reducing memory allocations, benchmark results: 

```
goos: darwin
goarch: amd64
pkg: github.com/f-amaral/go-async/async
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkJobResult_GetError_WhenError-12                1000000000               0.7768 ns/op          0 B/op          0 allocs/op
BenchmarkJobResult_GetError_WhenNoError-12              1000000000               0.9489 ns/op          0 B/op          0 allocs/op
BenchmarkProcessResult_GetErrors-12                     1000000000               0.7654 ns/op          0 B/op          0 allocs/op
BenchmarkProcessResult_GetErrors_WhenNoErrors-12        1000000000               0.7761 ns/op          0 B/op          0 allocs/op
PASS
ok      github.com/f-amaral/go-async/async      4.573s
goos: darwin
goarch: amd64
pkg: github.com/f-amaral/go-async/pool
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkJobPool_Process_WithoutErr-12            174267              6599 ns/op            2064 B/op          7 allocs/op
BenchmarkJobPool_Process_WithErr-12               174196              6540 ns/op            2064 B/op          7 allocs/op
PASS
ok      github.com/f-amaral/go-async/pool       2.686s
```